### PR TITLE
Allow `tls://` scheme for secure connection

### DIFF
--- a/src/RSocketConnector.php
+++ b/src/RSocketConnector.php
@@ -82,11 +82,11 @@ class RSocketConnector
         $uriArray = parse_url($url);
         if ($uriArray !== false && array_key_exists("scheme", $uriArray)) {
             $scheme = $uriArray['scheme'];
-            if ($scheme === 'tcp') {
+            if ('tls' === $scheme || 'tcp' === $scheme) {
                 $duplexConnPromise = (new Connector($loop))->connect($url)->then(function (ConnectionInterface $connection) {
                     return new TcpDuplexConnection($connection);
                 });
-            } else if ($scheme === 'ws') {
+            } else if ('ws' === $scheme) {
                 $duplexConnPromise = connect($url)->then(function ($webSocket) {
                     return new PawlWebSocketDuplexConnection($webSocket);
                 });


### PR DESCRIPTION
Allow `tls://` scheme for secure connection

### Motivation:

When server requires TLS connection there is no way to provide secure connection

### Modifications:

Allow `tls://` scheme for `connect` method

### Result:

Secure connection with server can be established 
