### PR TITLE
PHP version >=7.4 and <8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "docs": "https://github.com/rsocket/rsocket-php/wiki"
   },
   "require": {
-    "php": "7.4",
+    "php": "~7.4",
     "react/event-loop": "v1.1.1",
     "react/socket": "v1.6.0",
     "reactivex/rxphp": "2.0.7",


### PR DESCRIPTION
_[One line description of your change]_

Allow any 7.x PHP version

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

I'm having following error on composer `require` or `update` commands:

```
    - rsocket/rsocket-php dev-master requires php 7.4 -> your php version (7.4.14) does not satisfy that requirement.
```

### Modifications:

Changed required PHP version in composer.json

### Result:

Allow installation on local machine 7.4.14
