### PR TITLE
Payload frame encoding flags fix (according to JS library)

### DIFF
--- a/src/core/RSocketRequester.php
+++ b/src/core/RSocketRequester.php
@@ -127,7 +127,7 @@ class RSocketRequester implements RSocket
                 break;
             case FrameType::$ERROR:
                 if (array_key_exists($streamId, $this->senders)) {
-                    $error = new RSocketException($frame->code, $frame->message);
+                    $error = new RSocketException($frame->message, $frame->code);
                     if ($streamId === 0) {
                         ($this->errorConsumer)($error);
                     } else {

--- a/src/frame/FrameCodec.php
+++ b/src/frame/FrameCodec.php
@@ -174,11 +174,9 @@ class FrameCodec
         $frameBuffer = new ByteBuffer();
         $frameBuffer->writeI24(0); // frame length
         $frameBuffer->writeI32($streamId); //stream id
-        $flags = 0;
+        $flags = 0x20; // next
         if ($completed) {
             $flags |= 0x40; //complete
-        } else {
-            $flags |= 0x20; //next
         }
         self::writeTFrameTypeAndFlags($frameBuffer, FrameType::$PAYLOAD, $payload->metadata, $flags);
         self::writePayload($frameBuffer, $payload);


### PR DESCRIPTION
RSocketException code/message arguments order fix


### Motivation:

Responder reply is not accepted by a RSocket server because of missing "next" flag

### Modifications:

Payload encoder flags always includes "next" and "complete" when response was completed

### Result:

Flags include both "next" and "complete", server accepts the reply.